### PR TITLE
chore: Update flowbite script source to use local node_modules path

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,6 @@
     ></script>
     <script src="https://accounts.google.com/gsi/client" async></script>
     <script type="module" src="/src/main.jsx"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.4.1/flowbite.min.js"></script>
+    <script type="module" src="/node_modules/flowbite/dist/flowbite.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This pull request includes a change to the `index.html` file to update the source of the `flowbite` script. The change ensures that the `flowbite` script is loaded as a module from the local `node_modules` directory instead of from a CDN.

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L24-R24): Updated the source of the `flowbite` script to load from the local `node_modules` directory.