### PR TITLE
refactor: changing http and socket website source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.firebase
+.vite

--- a/src/helpers/http.js
+++ b/src/helpers/http.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const http = axios.create({
-  baseURL: 'http://localhost:3000/',
+  baseURL: 'https://tech-solve.superzeco.site/',
 });
 
 export default http;

--- a/src/util/socket.js
+++ b/src/util/socket.js
@@ -1,4 +1,4 @@
 import { io } from 'socket.io-client';
 
-export const socket = io('http://localhost:3000');
+export const socket = io('https://tech-solve.superzeco.site/');
 // console.log(socket);


### PR DESCRIPTION
This pull request updates the base URLs for the HTTP and WebSocket connections to point to the production server.

* [`src/helpers/http.js`](diffhunk://#diff-6d94dd4cb0f23534d8ba2b20d8e15196a660a734c8ae16574d5a27c89b25910eL4-R4): Changed the base URL for HTTP requests from `http://localhost:3000/` to `https://tech-solve.superzeco.site/`.
* [`src/util/socket.js`](diffhunk://#diff-51c20b3444e0af6d2cd1f6012f2288546d739e1a6b0f8b191cab101a9882de1aL3-R3): Updated the WebSocket connection URL from `http://localhost:3000` to `https://tech-solve.superzeco.site/`.